### PR TITLE
fix: Add release environment to publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ jobs:
   build-and-publish:
     name: Build and Push Docker Image to IOTA Registry
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
       # Checkout the repository


### PR DESCRIPTION
# Description

Sets the release environment to the publish workflow.

# Link to issues

https://github.com/iotaledger/iota-supply-service/issues/1